### PR TITLE
Improve handling of refresh tokens

### DIFF
--- a/src/pyop/authz_state.py
+++ b/src/pyop/authz_state.py
@@ -194,15 +194,16 @@ class AuthorizationState(object):
         if access_token_value not in self.access_tokens:
             raise InvalidAccessToken('{} unknown'.format(access_token_value))
 
-        refresh_token = rand_str()
-        authz_info = {'access_token': access_token_value}
-        if self.refresh_token_lifetime:
-            authz_info['exp'] = time.time() + self.refresh_token_lifetime
-            logger.debug('creating expiring refresh_token, valid_until=%s', authz_info['exp'])
+        if not self.refresh_token_lifetime:
+            logger.debug('no refresh token issued for for access_token=%s', access_token_value)
+            return None
 
+        refresh_token = rand_str()
+        authz_info = {'access_token': access_token_value, 'exp': time.time() + self.refresh_token_lifetime}
         self.refresh_tokens[refresh_token] = authz_info
 
-        logger.debug('issued refresh_token=%s for access_token=%s', refresh_token, access_token_value)
+        logger.debug('issued refresh_token=%s expiring=%d for access_token=%s', refresh_token, authz_info['exp'],
+                     access_token_value)
         return refresh_token
 
     def use_refresh_token(self, refresh_token, scope=None):

--- a/tests/pyop/test_authz_state.py
+++ b/tests/pyop/test_authz_state.py
@@ -34,9 +34,8 @@ class TestAuthorizationState(object):
         return functools.partial(AuthorizationState, HashBasedSubjectIdentifierFactory('salt'))
 
     @pytest.fixture
-    def authorization_state(self):
-        factory = self.authorization_state_factory()
-        return factory()
+    def authorization_state(self, authorization_state_factory):
+        return authorization_state_factory(refresh_token_lifetime=3600)
 
     def assert_access_token(self, access_token, access_token_db, iat):
         assert isinstance(access_token, AccessToken)
@@ -196,7 +195,17 @@ class TestAuthorizationState(object):
 
         assert refresh_token in authorization_state.refresh_tokens
         assert authorization_state.refresh_tokens[refresh_token]['access_token'] == access_token.value
-        assert 'exp' not in authorization_state.refresh_tokens[refresh_token]
+        assert 'exp' in authorization_state.refresh_tokens[refresh_token]
+
+    def test_create_refresh_token_issues_no_refresh_token_if_no_lifetime_is_specified(self, authorization_state_factory,
+                                                                                      authorization_request):
+        authorization_state = authorization_state_factory(refresh_token_lifetime=None)
+        self.set_valid_subject_identifier(authorization_state)
+
+        access_token = authorization_state.create_access_token(authorization_request, self.TEST_SUBJECT_IDENTIFIER)
+        refresh_token = authorization_state.create_refresh_token(access_token.value)
+
+        assert refresh_token is None
 
     @pytest.mark.parametrize('access_token', INVALID_INPUT)
     def test_create_refresh_token_with_invalid_access_token_value(self, access_token, authorization_state):
@@ -217,7 +226,8 @@ class TestAuthorizationState(object):
         assert authorization_state.refresh_tokens[refresh_token]['exp'] == time.time() + refresh_token_lifetime
 
     def test_use_refresh_token(self, authorization_state_factory, authorization_request):
-        authorization_state = authorization_state_factory(access_token_lifetime=self.TEST_TOKEN_LIFETIME)
+        authorization_state = authorization_state_factory(access_token_lifetime=self.TEST_TOKEN_LIFETIME,
+                                                          refresh_token_lifetime=300)
         self.set_valid_subject_identifier(authorization_state)
 
         with patch('time.time', MOCK_TIME):

--- a/tests/pyop/test_provider.py
+++ b/tests/pyop/test_provider.py
@@ -345,6 +345,8 @@ class TestProviderHandleTokenRequest(object):
             self.provider.handle_token_request(urlencode(self.authorization_code_exchange_request_args))
 
     def test_refresh_request(self):
+        self.provider.authz_state = AuthorizationState(HashBasedSubjectIdentifierFactory('salt'),
+                                                       refresh_token_lifetime=600)
         self.refresh_token_request_args['refresh_token'] = self.create_refresh_token()
         response = self.provider.handle_token_request(urlencode(self.refresh_token_request_args))
         assert response['access_token'] in self.provider.authz_state.access_tokens
@@ -363,6 +365,8 @@ class TestProviderHandleTokenRequest(object):
         assert response['refresh_token'] in self.provider.authz_state.refresh_tokens
 
     def test_refresh_request_without_scope_parameter_defaults_to_scope_from_authentication_request(self):
+        self.provider.authz_state = AuthorizationState(HashBasedSubjectIdentifierFactory('salt'),
+                                                       refresh_token_lifetime=600)
         self.refresh_token_request_args['refresh_token'] = self.create_refresh_token()
         del self.refresh_token_request_args['scope']
         response = self.provider.handle_token_request(urlencode(self.refresh_token_request_args))


### PR DESCRIPTION
* Only issue refresh tokens if `AuthorizationState.refresh_token_lifetime` is set.
* Only issue a renewed refresh token if `AuthorizationState.refresh_token_threshold` is set.