### PR TITLE
Improve finding access token in userinfo request.

### DIFF
--- a/src/pyop/access_token.py
+++ b/src/pyop/access_token.py
@@ -18,24 +18,22 @@ class AccessToken(object):
         self.type = typ
 
 
-def extract_bearer_token_from_http_request(request=None, http_headers=None):
-    # type (Optional[str], Optional[Mapping[str, str]] -> str
+def extract_bearer_token_from_http_request(parsed_request=None, authz_header=None):
+    # type (Optional[Mapping[str, str]], Optional[str] -> str
     """
     Extracts a Bearer token from an http request
-    :param request: form-encoded request (URL query part of request body)
-    :param http_headers: http request headers
+    :param parsed_request: parsed request (URL query part of request body)
+    :param authz_header: HTTP Authorization header
     :return: Bearer access token, if found
     :raise BearerTokenError: if no Bearer token could be extracted from the request
     """
-    if http_headers and 'Authorization' in http_headers:
+    if authz_header:
         # Authorization Request Header Field: https://tools.ietf.org/html/rfc6750#section-2.1
-        authz_header = http_headers['Authorization']
         if authz_header.startswith(AccessToken.BEARER_TOKEN_TYPE):
             access_token = authz_header[len(AccessToken.BEARER_TOKEN_TYPE) + 1:]
             logger.debug('found access token %s in authz header', access_token)
             return access_token
-    elif request:
-        parsed_request = dict(parse_qsl(request))
+    elif parsed_request:
         if 'access_token' in parsed_request:
             """
             Form-Encoded Body Parameter: https://tools.ietf.org/html/rfc6750#section-2.2, and

--- a/src/pyop/provider.py
+++ b/src/pyop/provider.py
@@ -407,7 +407,10 @@ class Provider(object):
         :param request: urlencoded request (either query string or POST body)
         :param http_headers: http headers
         """
-        bearer_token = extract_bearer_token_from_http_request(request, http_headers)
+        if http_headers is None:
+            http_headers = {}
+        userinfo_request = dict(parse_qsl(request))
+        bearer_token = extract_bearer_token_from_http_request(userinfo_request, http_headers.get('Authorization'))
 
         introspection = self.authz_state.introspect_access_token(bearer_token)
         if not introspection['active']:

--- a/tests/pyop/test_access_token.py
+++ b/tests/pyop/test_access_token.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlencode
-
 import pytest
 
 from pyop.access_token import extract_bearer_token_from_http_request, BearerTokenError
@@ -9,24 +7,22 @@ ACCESS_TOKEN = 'abcdef'
 
 class TestExtractBearerTokenFromHttpRequest(object):
     def test_authorization_header(self):
-        http_headers = {'Authorization': 'Bearer {}'.format(ACCESS_TOKEN)}
-        assert extract_bearer_token_from_http_request(http_headers=http_headers) == ACCESS_TOKEN
+        assert extract_bearer_token_from_http_request(authz_header='Bearer {}'.format(ACCESS_TOKEN)) == ACCESS_TOKEN
 
     def test_non_bearer_authorization_header(self):
-        http_headers = {'Authorization': 'Basic {}'.format(ACCESS_TOKEN)}
         with pytest.raises(BearerTokenError):
-            extract_bearer_token_from_http_request(http_headers=http_headers)
+            extract_bearer_token_from_http_request(authz_header='Basic {}'.format(ACCESS_TOKEN))
 
-    def test_access_token_in_urlencoded_request(self):
+    def test_access_token_in_request(self):
         data = {
             'foo': 'bar',
             'access_token': ACCESS_TOKEN
         }
-        assert extract_bearer_token_from_http_request(request=urlencode(data)) == ACCESS_TOKEN
+        assert extract_bearer_token_from_http_request(data) == ACCESS_TOKEN
 
-    def test_urlencoded_request_without_access_token(self):
+    def test_request_without_access_token(self):
         data = {
             'foo': 'bar',
         }
         with pytest.raises(BearerTokenError):
-            extract_bearer_token_from_http_request(request=urlencode(data))
+            extract_bearer_token_from_http_request(data)


### PR DESCRIPTION
If the token is contained in the request body, and the Authorization
header is present but empty, the token could not be discovered.
This simplification of extract_bearer_token_from_http_request(),
ensures easier detection of this case.